### PR TITLE
feat: allow to show a preview by double-clicking on an element

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use the i18n pipe in templates to translate text:
 
 ```html
 {{ 'preview.toolbar.zoomIn' | i18n }}
-// With parameters 
+// With parameters
 // Use ${0} as a numeric placeholder in the corresponding text. The number of placeholders is unlimited, but you must pass the corresponding number of arguments when using them.
 // example: list.total ==> "共${0}个文件"
 {{ 'list.total' | i18n:filesCount }}
@@ -259,14 +259,15 @@ type PreviewType =
 
 ### PreviewListComponent
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| files | PreviewFile[] | [] | List of files to preview |
-| themeMode | 'light' \| 'dark' \| 'auto' | 'auto' | Theme mode for the preview |
-| autoConfig | { dark: { start: number, end: number } } | { dark: { start: 19, end: 7 } } | Auto theme mode configuration |
+| Property | Type | Default | Description                                                                    |
+|----------|------|---------|--------------------------------------------------------------------------------|
+| files | PreviewFile[] | [] | List of files to preview                                                       |
+| doubleClick | boolean | false | Show a preview by double-clicking on an element                                |
+| themeMode | 'light' \| 'dark' \| 'auto' | 'auto' | Theme mode for the preview                                                     |
+| autoConfig | { dark: { start: number, end: number } } | { dark: { start: 19, end: 7 } } | Auto theme mode configuration                                                  |
 | lang | string | 'zh' | Internationalization language setting, 'zh' and 'en' are registered by default |
-| (fileSelect) | EventEmitter<PreviewFile> | - | Event emitted when a file is selected |
-| (previewEvent) | EventEmitter<PreviewEvent> | - | Event emitted during preview actions |
+| (fileSelect) | EventEmitter<PreviewFile> | - | Event emitted when a file is selected                                          |
+| (previewEvent) | EventEmitter<PreviewEvent> | - | Event emitted during preview actions                                           |
 
 #### Template Context Variables
 
@@ -281,13 +282,14 @@ type PreviewType =
 
 ### PreviewDirective
 
-| Selector | Property | Type | Default | Description |
-|----------|----------|------|---------|-------------|
-| [ngxFilePreview] | ngxFilePreview | PreviewFile \| PreviewFile[] | - | File(s) to preview |
-| | themeMode | 'light' \| 'dark' \| 'auto' | 'auto' | Theme mode for the preview |
-| | autoConfig | { dark: { start: number, end: number } } | { dark: { start: 19, end: 7 } } | Auto theme mode configuration |
-| | lang | string | 'zh' | Internationalization language setting, 'zh' and 'en' are registered by default |
-| | (previewEvent) | EventEmitter<PreviewEvent> | - | Event emitted during preview actions |
+| Selector | Property       | Type                                     | Default                         | Description                                                            |
+|----------|----------------|------------------------------------------|---------------------------------|------------------------------------------------------------------------|
+| [ngxFilePreview] | ngxFilePreview | PreviewFile \| PreviewFile[]             | -                               | File(s) to preview                                                     |
+| | doubleClick    | boolean                                  | false                           | Show a preview by double-clicking on an element                        |
+| | themeMode      | 'light' \| 'dark' \| 'auto'              | 'auto'                          | Theme mode for the preview                                             |
+| | autoConfig     | { dark: { start: number, end: number } } | { dark: { start: 19, end: 7 } } | Auto theme mode configuration                                          |
+| | lang           | string                                   | 'zh'                            | Internationalization language setting, 'zh' and 'en' are registered by default |
+| | (previewEvent) | EventEmitter<PreviewEvent>               | -                               | Event emitted during preview actions                                   |
 
 ### PreviewEvent Types
 

--- a/libs/demo/src/app/app.component.html
+++ b/libs/demo/src/app/app.component.html
@@ -48,6 +48,18 @@
         <div class="preview-section">
           <div class="title-container">
             <div class="title">
+              <span>{{i18nText[currentLang].basicUsage}}</span>
+              <ngx-theme-icon [themeMode]="directiveTheme" (click)="changeDirectiveTheme()"></ngx-theme-icon>
+            </div>
+            <span class="source-code" (click)="showSourceCode('directive')">{{i18nText[currentLang].viewSourceCode}}</span>
+          </div>
+          <div class="directive" [ngxFilePreview]="files" [doubleClick]="true" [themeMode]="directiveTheme" (previewEvent)="handleError($event)">
+            Double click for preview
+          </div>
+        </div>
+        <div class="preview-section">
+          <div class="title-container">
+            <div class="title">
               <span>{{i18nText[currentLang].i18nDemo}}</span>
               <ngx-theme-icon [themeMode]="directiveI18nTheme" (click)="changeDirectiveI18nTheme()"></ngx-theme-icon>
             </div>
@@ -72,6 +84,7 @@
           <ngx-preview-list
             #list
             [files]="files"
+            [doubleClick]="true"
             themeMode="auto"
             [autoConfig]="{dark: { start: 18, end: 6 }}"
           ></ngx-preview-list>
@@ -85,7 +98,7 @@
             </div>
             <span class="source-code" (click)="showSourceCode('custom')">{{i18nText[currentLang].viewSourceCode}}</span>
           </div>
-          <ngx-preview-list #custom [files]="files" themeMode="light" [lang]="'en'">
+          <ngx-preview-list #custom [files]="files" [doubleClick]="true" themeMode="light" [lang]="'en'">
             <ng-template
               #itemTemplate
               let-file

--- a/libs/ngx-file-preview/src/lib/directives/preview.directive.ts
+++ b/libs/ngx-file-preview/src/lib/directives/preview.directive.ts
@@ -52,6 +52,9 @@ export class PreviewDirective implements OnDestroy {
   }
   @Output() previewEvent = new EventEmitter<PreviewEvent>();
 
+
+  @Input() doubleClick: boolean = false;
+
   t(key: string, ...args: (string | number)[]) {
     return this.previewService?.getLangParser()?.t(key, ...args);
   }
@@ -64,6 +67,21 @@ export class PreviewDirective implements OnDestroy {
   onClick(e:MouseEvent) {
     e.preventDefault()
     e.stopImmediatePropagation();
+    if (!this.doubleClick) {
+      this.clickHandler();
+    }
+  }
+
+  @HostListener('dblclick', ['$event'])
+  handleDoubleClick(e: MouseEvent) {
+    e.preventDefault()
+    e.stopImmediatePropagation();
+    if (this.doubleClick) {
+      this.clickHandler();
+    }
+  }
+
+  private clickHandler():void {
     if (!this.fileInput) return;
     const files = PreviewUtils.normalizeFiles(this.fileInput);
     if (files.length > 0) {

--- a/libs/ngx-file-preview/src/lib/preview-list/preview-list.component.html
+++ b/libs/ngx-file-preview/src/lib/preview-list/preview-list.component.html
@@ -33,6 +33,7 @@
         <div class="item"
              (click)="triggerSelect(i)"
              [ngxFilePreview]="file"
+             [doubleClick]="doubleClick"
              [themeMode]="themeMode"
              [lang]="lang"
              [class.active]="i === index">

--- a/libs/ngx-file-preview/src/lib/preview-list/preview-list.component.ts
+++ b/libs/ngx-file-preview/src/lib/preview-list/preview-list.component.ts
@@ -50,6 +50,7 @@ export class PreviewListComponent {
     this._files = PreviewUtils.normalizeFiles(value);
   }
 
+  @Input() doubleClick = false;
   @Input() index = 0;
   private _themeMode: ThemeMode = 'auto';
   @Input()


### PR DESCRIPTION
I really missed this feature, so I decided to add a preview when an item is double-clicked. I think users can expect this behaviour when they want to preview something. The most obvious example of this is the preview function in Google Drive.